### PR TITLE
Colon setter and brightness range fixed.

### DIFF
--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -74,6 +74,10 @@ TM1637Display::TM1637Display(uint8_t pinClk, uint8_t pinDIO)
 void TM1637Display::setBrightness(uint8_t brightness)
 {
 	m_brightness = brightness;
+
+void TM1637Display::setColon(bool colon)
+{
+  m_colon = colon;
 }
 
 void TM1637Display::setSegments(const uint8_t segments[], uint8_t length, uint8_t pos)
@@ -86,11 +90,19 @@ void TM1637Display::setSegments(const uint8_t segments[], uint8_t length, uint8_
 	// Write COMM2 + first digit address
 	start();
 	writeByte(TM1637_I2C_COMM2 + (pos & 0x03));
-	
+  
 	// Write the data bytes
-	for (uint8_t k=0; k < length; k++) 
-	  writeByte(segments[k]);
-	  
+  uint8_t currentByte = 0x00; 
+	for (uint8_t k=0; k < length; k++){
+    currentByte = segments[k] & 0x7f;
+    if(k == COLON_POSITION){
+      if(m_colon){
+        currentByte |= 0x80;
+      }
+    }
+    writeByte(currentByte);
+  }
+	
 	stop();
 
 	// Write COMM3 + brightness

--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -73,7 +73,12 @@ TM1637Display::TM1637Display(uint8_t pinClk, uint8_t pinDIO)
 
 void TM1637Display::setBrightness(uint8_t brightness)
 {
-	m_brightness = brightness;
+  if(brightness > 0){
+  	m_brightness = ((brightness - 1) & 0x07) | 0x08;
+  } else {
+    m_brightness = 0x00;
+  }
+}
 
 void TM1637Display::setColon(bool colon)
 {

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -27,6 +27,9 @@
 #define SEG_F   0b00100000
 #define SEG_G   0b01000000
 
+// Defines which element's highest bit is the colon's control bit
+#define COLON_POSITION 1
+
 class TM1637Display {
 
 public:
@@ -42,8 +45,12 @@ public:
   //! The setting takes effect when a command is given to change the data being
   //! displayed.
   //!
-  //! @param brightness A number from 0 (lowes brightness) to 7 (highest brightness)
+  //! @param brightness A number from 0 (Off) to 8 (highest brightness)
   void setBrightness(uint8_t brightness);
+  
+  //! Sets the colon indicator mode on or off
+  //! @param colon When true, lights up the colon on next use of showNumberDec
+  void setColon(const bool colon);
   
   //! Display arbitrary data on the module
   //!
@@ -96,6 +103,7 @@ private:
 	uint8_t m_pinClk;
 	uint8_t m_pinDIO;
 	uint8_t m_brightness;
+  bool m_colon;
 };
 
 #endif // __TM1637DISPLAY__


### PR DESCRIPTION
The previous colon changes were not merged I see because it wasn't supported across the different functions. This will only regard the boolean value.

Secondly I thought it was weird to have to set the enable bit through the `setBrightness` function. This uses a range of 0-8 where 0 == Off. (See #6)
