### PR TITLE
`SetBrightness` changes the brightness immediately

### DIFF
--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -71,9 +71,14 @@ TM1637Display::TM1637Display(uint8_t pinClk, uint8_t pinDIO)
 	digitalWrite(m_pinDIO, LOW);
 }
 
-void TM1637Display::setBrightness(uint8_t brightness, bool on)
+void TM1637Display::setBrightness(uint8_t brightness)
 {
-	m_brightness = (brightness & 0x7) | (on? 0x08 : 0x00);
+	if (brightness > 8) brightness = 8;
+ 	if (!brightness) m_brightness = 0x00;
+	else m_brightness = 0x08 | (brightness - 1);
+ 	start();
+	writeByte(TM1637_I2C_COMM3 + m_brightness);
+	stop();
 }
 
 void TM1637Display::setSegments(const uint8_t segments[], uint8_t length, uint8_t pos)
@@ -95,7 +100,7 @@ void TM1637Display::setSegments(const uint8_t segments[], uint8_t length, uint8_
 
 	// Write COMM3 + brightness
 	start();
-	writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
+	writeByte(TM1637_I2C_COMM3 + m_brightness);
 	stop();
 }
 

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -39,12 +39,10 @@ public:
 
   //! Sets the brightness of the display.
   //!
-  //! The setting takes effect when a command is given to change the data being
-  //! displayed.
+  //! The setting takes effect instantly keeping the data displayed.
   //!
-  //! @param brightness A number from 0 (lowes brightness) to 7 (highest brightness)
-  //! @param on Turn display on or off
-  void setBrightness(uint8_t brightness, bool on = true);
+  //! @param brightness A number from 0 (turn off) to 8 (highest brightness)
+  void setBrightness(uint8_t brightness);
 
   //! Display arbitrary data on the module
   //!

--- a/examples/TM1637Test/TM1637Test.ino
+++ b/examples/TM1637Test/TM1637Test.ino
@@ -25,7 +25,7 @@ void loop()
 {
   int k;
   uint8_t data[] = { 0xff, 0xff, 0xff, 0xff };
-  display.setBrightness(0x0f);
+  display.setBrightness(8);
 
   // All segments on
   display.setSegments(data);
@@ -87,20 +87,19 @@ void loop()
   delay(TEST_DELAY);
 
   // Brightness Test
-  for(k = 0; k < 4; k++)
-	data[k] = 0xff;
-  for(k = 0; k < 7; k++) {
+  for(k = 0; k < 4; k++) data[k] = 0xff;
+  display.setSegments(data);
+  for(k = 0; k < 9; k++) {
     display.setBrightness(k);
-    display.setSegments(data);
     delay(TEST_DELAY);
   }
   
   // On/Off test
   for(k = 0; k < 4; k++) {
-    display.setBrightness(7, false);  // Turn off
+    display.setBrightness(0);  // Turn off
     display.setSegments(data);
     delay(TEST_DELAY);
-    display.setBrightness(7, true); // Turn on
+    display.setBrightness(8); // Turn on
     display.setSegments(data);
     delay(TEST_DELAY);  
   }


### PR DESCRIPTION
Modified the behavior of `setBrightness` to allow to turn on, turn off and modify the brightness of the display from a single variable, using a single call. In addition I have corrected the operating range according to datasheet.
These changes can break codes that use the previous behavior.