### PR TITLE
changing bitDelay to 5μs.

### DIFF
--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -141,7 +141,7 @@ void TM1637Display::showNumberDecEx(int num, uint8_t dots, bool leading_zero,
 
 void TM1637Display::bitDelay()
 {
-	delayMicroseconds(50);
+	delayMicroseconds(5);
 }
 
 void TM1637Display::start()


### PR DESCRIPTION
The previous 50μs bitDelay is unnecessary high. I found 5μs to work well, and I've seen this value beeing used in other example code for the TM1637.