### PR TITLE
Increases bitDelay to 100ms

### DIFF
--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -141,7 +141,7 @@ void TM1637Display::showNumberDecEx(int num, uint8_t dots, bool leading_zero,
 
 void TM1637Display::bitDelay()
 {
-	delayMicroseconds(50);
+	delayMicroseconds(100);
 }
 
 void TM1637Display::start()


### PR DESCRIPTION
Some boards on ebay have high value pullups and smoothing caps that mean that 50ms is not enough, raise that to 100ms.

resolves #18