### PR TITLE
Add maintainer field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,7 @@
 name=TM1637
 version=1.1.1
 author=Avishay Orpaz <avishorp@gmail.com>
+maintainer=Avishay Orpaz <avishorp@gmail.com>
 sentence=Driver for 4 digit 7-segment display modules, based on the TM1637 chip.
 paragraph=These chips can be found in cheap display modules. They communicate with the processor in I2C-like protocol. The implementation is pure software emulation and doesn't make use of any special hardware (other than GPIO pins). It is assumed that pull-up resistors are present (usually integrated in the display module).
 category=Display


### PR DESCRIPTION
The maintainer field is required by the Arduino IDE. Attempting to install a library missing this field via the Arduino IDE's Sketch > Include library > Add .ZIP library fails silently. If the library is installed manually then compilation of any sketch that includes it fails.

This change is required before pursuing https://github.com/avishorp/TM1637/issues/22