### PR TITLE
Add functions to display text

### DIFF
--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -16,9 +16,9 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 extern "C" {
-  #include <stdlib.h>
-  #include <string.h>
-  #include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
 }
 
 #include <TM1637Display.h>
@@ -37,223 +37,225 @@ extern "C" {
 //     ---
 //      D
 const uint8_t digitToSegment[] = {
- // XGFEDCBA
-  0b00111111,    // 0
-  0b00000110,    // 1
-  0b01011011,    // 2
-  0b01001111,    // 3
-  0b01100110,    // 4
-  0b01101101,    // 5
-  0b01111101,    // 6
-  0b00000111,    // 7
-  0b01111111,    // 8
-  0b01101111,    // 9
-  0b01110111,    // A
-  0b01111100,    // b
-  0b00111001,    // C
-  0b01011110,    // d
-  0b01111001,    // E
-  0b01110001     // F
-  };
+// XGFEDCBA
+    0b00111111,    // 0
+    0b00000110,    // 1
+    0b01011011,    // 2
+    0b01001111,    // 3
+    0b01100110,    // 4
+    0b01101101,    // 5
+    0b01111101,    // 6
+    0b00000111,    // 7
+    0b01111111,    // 8
+    0b01101111,    // 9
+    0b01110111,    // A
+    0b01111100,    // b
+    0b00111001,    // C
+    0b01011110,    // d
+    0b01111001,    // E
+    0b01110001     // F
+};
 
 static const uint8_t lowercaseToSegment[] = {
     0b1011111, 0b1111100, 0b1011000, 0b1011110, 0b1111011, 0b1110001,
     0b1101111, 0b1110100, 0b0000100, 0b0001110, 0b1110100, 0b0110000,
     0b1010101, 0b1010100, 0b1011100, 0b1110011, 0b1100111, 0b1010000,
     0b1101101, 0b1111000, 0b0011100, 0b1100010, 0b1101010, 0b1010010,
-    0b1100110, 0b1011011 };
+    0b1100110, 0b1011011
+};
 
 static const uint8_t uppercaseToSegment[] = {
     0b1110111, 0b1111111, 0b0111001, 0b0111111, 0b1111001, 0b1110001,
     0b0111101, 0b1110110, 0b0000110, 0b0011110, 0b1110110, 0b0111000,
     0b1010101, 0b1010100, 0b0111111, 0b1110011, 0b1100111, 0b1110111,
     0b1101101, 0b0110001, 0b0111110, 0b1110010, 0b1111110, 0b1010010,
-    0b1101110, 0b1011011 };
+    0b1101110, 0b1011011
+};
 
 static const uint8_t minusSegments = 0b01000000;
 
 TM1637Display::TM1637Display(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay)
 {
-	// Copy the pin numbers
-	m_pinClk = pinClk;
-	m_pinDIO = pinDIO;
-	m_bitDelay = bitDelay;
+    // Copy the pin numbers
+    m_pinClk = pinClk;
+    m_pinDIO = pinDIO;
+    m_bitDelay = bitDelay;
 
-	// Set the pin direction and default value.
-	// Both pins are set as inputs, allowing the pull-up resistors to pull them up
+    // Set the pin direction and default value.
+    // Both pins are set as inputs, allowing the pull-up resistors to pull them up
     pinMode(m_pinClk, INPUT);
     pinMode(m_pinDIO,INPUT);
-	digitalWrite(m_pinClk, LOW);
-	digitalWrite(m_pinDIO, LOW);
+    digitalWrite(m_pinClk, LOW);
+    digitalWrite(m_pinDIO, LOW);
 }
 
 void TM1637Display::setBrightness(uint8_t brightness, bool on)
 {
-	m_brightness = (brightness & 0x7) | (on? 0x08 : 0x00);
+    m_brightness = (brightness & 0x7) | (on? 0x08 : 0x00);
 }
 
 void TM1637Display::setSegments(const uint8_t segments[], uint8_t length, uint8_t pos)
 {
     // Write COMM1
-	start();
-	writeByte(TM1637_I2C_COMM1);
-	stop();
+    start();
+    writeByte(TM1637_I2C_COMM1);
+    stop();
 
-	// Write COMM2 + first digit address
-	start();
-	writeByte(TM1637_I2C_COMM2 + (pos & 0x03));
+    // Write COMM2 + first digit address
+    start();
+    writeByte(TM1637_I2C_COMM2 + (pos & 0x03));
 
-	// Write the data bytes
-	for (uint8_t k=0; k < length; k++)
-	  writeByte(segments[k]);
+    // Write the data bytes
+    for (uint8_t k=0; k < length; k++)
+        writeByte(segments[k]);
 
-	stop();
+    stop();
 
-	// Write COMM3 + brightness
-	start();
-	writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
-	stop();
+    // Write COMM3 + brightness
+    start();
+    writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
+    stop();
 }
 
 void TM1637Display::clear()
 {
     uint8_t data[] = { 0, 0, 0, 0 };
-	setSegments(data);
+    setSegments(data);
 }
 
 void TM1637Display::showNumberDec(int num, bool leading_zero, uint8_t length, uint8_t pos)
 {
-  showNumberDecEx(num, 0, leading_zero, length, pos);
+    showNumberDecEx(num, 0, leading_zero, length, pos);
 }
 
 void TM1637Display::showNumberDecEx(int num, uint8_t dots, bool leading_zero,
                                     uint8_t length, uint8_t pos)
 {
-  showNumberBaseEx(num < 0? -10 : 10, num < 0? -num : num, dots, leading_zero, length, pos);
+    showNumberBaseEx(num < 0? -10 : 10, num < 0? -num : num, dots, leading_zero, length, pos);
 }
 
 void TM1637Display::showNumberHexEx(uint16_t num, uint8_t dots, bool leading_zero,
                                     uint8_t length, uint8_t pos)
 {
-  showNumberBaseEx(16, num, dots, leading_zero, length, pos);
+    showNumberBaseEx(16, num, dots, leading_zero, length, pos);
 }
 
 void TM1637Display::showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots, bool leading_zero,
-                                    uint8_t length, uint8_t pos)
+                                     uint8_t length, uint8_t pos)
 {
     bool negative = false;
-	if (base < 0) {
-	    base = -base;
-		negative = true;
-	}
+    if (base < 0) {
+        base = -base;
+        negative = true;
+    }
 
 
     uint8_t digits[4];
 
-	if (num == 0 && !leading_zero) {
-		// Singular case - take care separately
-		for(uint8_t i = 0; i < (length-1); i++)
-			digits[i] = 0;
-		digits[length-1] = encodeDigit(0);
-	}
-	else {
-		//uint8_t i = length-1;
-		//if (negative) {
-		//	// Negative number, show the minus sign
-		//    digits[i] = minusSegments;
-		//	i--;
-		//}
-		
-		for(int i = length-1; i >= 0; --i)
-		{
-		    uint8_t digit = num % base;
-			
-			if (digit == 0 && num == 0 && leading_zero == false)
-			    // Leading zero is blank
-				digits[i] = 0;
-			else
-			    digits[i] = encodeDigit(digit);
-				
-			if (digit == 0 && num == 0 && negative) {
-			    digits[i] = minusSegments;
-				negative = false;
-			}
+    if (num == 0 && !leading_zero) {
+        // Singular case - take care separately
+        for(uint8_t i = 0; i < (length-1); i++)
+            digits[i] = 0;
+        digits[length-1] = encodeDigit(0);
+    }
+    else {
+        //uint8_t i = length-1;
+        //if (negative) {
+        //	// Negative number, show the minus sign
+        //    digits[i] = minusSegments;
+        //	i--;
+        //}
 
-			num /= base;
-		}
+        for(int i = length-1; i >= 0; --i)
+        {
+            uint8_t digit = num % base;
 
-		if(dots != 0)
-		{
-			showDots(dots, digits);
-		}
+            if (digit == 0 && num == 0 && leading_zero == false)
+                // Leading zero is blank
+                digits[i] = 0;
+            else
+                digits[i] = encodeDigit(digit);
+
+            if (digit == 0 && num == 0 && negative) {
+                digits[i] = minusSegments;
+                negative = false;
+            }
+
+            num /= base;
+        }
+
+        if(dots != 0)
+        {
+            showDots(dots, digits);
+        }
     }
     setSegments(digits, length, pos);
 }
 
 void TM1637Display::bitDelay()
 {
-	delayMicroseconds(m_bitDelay);
+    delayMicroseconds(m_bitDelay);
 }
 
 void TM1637Display::start()
 {
-  pinMode(m_pinDIO, OUTPUT);
-  bitDelay();
+    pinMode(m_pinDIO, OUTPUT);
+    bitDelay();
 }
 
 void TM1637Display::stop()
 {
-	pinMode(m_pinDIO, OUTPUT);
-	bitDelay();
-	pinMode(m_pinClk, INPUT);
-	bitDelay();
-	pinMode(m_pinDIO, INPUT);
-	bitDelay();
+    pinMode(m_pinDIO, OUTPUT);
+    bitDelay();
+    pinMode(m_pinClk, INPUT);
+    bitDelay();
+    pinMode(m_pinDIO, INPUT);
+    bitDelay();
 }
 
 bool TM1637Display::writeByte(uint8_t b)
 {
-  uint8_t data = b;
+    uint8_t data = b;
 
-  // 8 Data Bits
-  for(uint8_t i = 0; i < 8; i++) {
-    // CLK low
+    // 8 Data Bits
+    for(uint8_t i = 0; i < 8; i++) {
+        // CLK low
+        pinMode(m_pinClk, OUTPUT);
+        bitDelay();
+
+        // Set data bit
+        if (data & 0x01)
+            pinMode(m_pinDIO, INPUT);
+        else
+            pinMode(m_pinDIO, OUTPUT);
+
+        bitDelay();
+
+        // CLK high
+        pinMode(m_pinClk, INPUT);
+        bitDelay();
+        data = data >> 1;
+    }
+
+    // Wait for acknowledge
+    // CLK to zero
+    pinMode(m_pinClk, OUTPUT);
+    pinMode(m_pinDIO, INPUT);
+    bitDelay();
+
+    // CLK to high
+    pinMode(m_pinClk, INPUT);
+    bitDelay();
+    uint8_t ack = digitalRead(m_pinDIO);
+    if (ack == 0)
+        pinMode(m_pinDIO, OUTPUT);
+
+
+    bitDelay();
     pinMode(m_pinClk, OUTPUT);
     bitDelay();
 
-	// Set data bit
-    if (data & 0x01)
-      pinMode(m_pinDIO, INPUT);
-    else
-      pinMode(m_pinDIO, OUTPUT);
-
-    bitDelay();
-
-	// CLK high
-    pinMode(m_pinClk, INPUT);
-    bitDelay();
-    data = data >> 1;
-  }
-
-  // Wait for acknowledge
-  // CLK to zero
-  pinMode(m_pinClk, OUTPUT);
-  pinMode(m_pinDIO, INPUT);
-  bitDelay();
-
-  // CLK to high
-  pinMode(m_pinClk, INPUT);
-  bitDelay();
-  uint8_t ack = digitalRead(m_pinDIO);
-  if (ack == 0)
-    pinMode(m_pinDIO, OUTPUT);
-
-
-  bitDelay();
-  pinMode(m_pinClk, OUTPUT);
-  bitDelay();
-
-  return ack;
+    return ack;
 }
 
 void TM1637Display::showDots(uint8_t dots, uint8_t* digits)
@@ -267,7 +269,7 @@ void TM1637Display::showDots(uint8_t dots, uint8_t* digits)
 
 uint8_t TM1637Display::encodeDigit(uint8_t digit)
 {
-	return digitToSegment[digit & 0x0f];
+    return digitToSegment[digit & 0x0f];
 }
 
 uint8_t TM1637Display::encodeChar(char c)

--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -56,6 +56,20 @@ const uint8_t digitToSegment[] = {
   0b01110001     // F
   };
 
+static const uint8_t lowercaseToSegment[] = {
+    0b1011111, 0b1111100, 0b1011000, 0b1011110, 0b1111011, 0b1110001,
+    0b1101111, 0b1110100, 0b0000100, 0b0001110, 0b1110100, 0b0110000,
+    0b1010101, 0b1010100, 0b1011100, 0b1110011, 0b1100111, 0b1010000,
+    0b1101101, 0b1111000, 0b0011100, 0b1100010, 0b1101010, 0b1010010,
+    0b1100110, 0b1011011 };
+
+static const uint8_t uppercaseToSegment[] = {
+    0b1110111, 0b1111111, 0b0111001, 0b0111111, 0b1111001, 0b1110001,
+    0b0111101, 0b1110110, 0b0000110, 0b0011110, 0b1110110, 0b0111000,
+    0b1010101, 0b1010100, 0b0111111, 0b1110011, 0b1100111, 0b1110111,
+    0b1101101, 0b0110001, 0b0111110, 0b1110010, 0b1111110, 0b1010010,
+    0b1101110, 0b1011011 };
+
 static const uint8_t minusSegments = 0b01000000;
 
 TM1637Display::TM1637Display(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay)
@@ -254,4 +268,29 @@ void TM1637Display::showDots(uint8_t dots, uint8_t* digits)
 uint8_t TM1637Display::encodeDigit(uint8_t digit)
 {
 	return digitToSegment[digit & 0x0f];
+}
+
+uint8_t TM1637Display::encodeChar(char c)
+{
+    if (c >= '0' && c <= '9')
+        return encodeDigit(c - '0');
+
+    if (c >= 'a' && c <= 'z')
+        return lowercaseToSegment[c - 'a'];
+
+    if (c >= 'A' && c <= 'Z')
+        return uppercaseToSegment[c - 'A'];
+
+    if (c == '-')
+        return minusSegments;
+
+    return 0;
+}
+
+void TM1637Display::showText(const char * text, uint8_t length, uint8_t pos)
+{
+    uint8_t segments[] = { 0, 0, 0, 0 };
+    for (int i = 0; i < length && i < 4 && text[i]; ++i)
+        segments[i] = encodeChar(text[i]);
+    setSegments(segments, length, pos);
 }

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -33,158 +33,158 @@
 class TM1637Display {
 
 public:
-  //! Initialize a TM1637Display object, setting the clock and
-  //! data pins.
-  //!
-  //! @param pinClk - The number of the digital pin connected to the clock pin of the module
-  //! @param pinDIO - The number of the digital pin connected to the DIO pin of the module
-  //! @param bitDelay - The delay, in microseconds, between bit transition on the serial
-  //!                   bus connected to the display
-  TM1637Display(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay = DEFAULT_BIT_DELAY);
+    //! Initialize a TM1637Display object, setting the clock and
+    //! data pins.
+    //!
+    //! @param pinClk - The number of the digital pin connected to the clock pin of the module
+    //! @param pinDIO - The number of the digital pin connected to the DIO pin of the module
+    //! @param bitDelay - The delay, in microseconds, between bit transition on the serial
+    //!                   bus connected to the display
+    TM1637Display(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay = DEFAULT_BIT_DELAY);
 
-  //! Sets the brightness of the display.
-  //!
-  //! The setting takes effect when a command is given to change the data being
-  //! displayed.
-  //!
-  //! @param brightness A number from 0 (lowes brightness) to 7 (highest brightness)
-  //! @param on Turn display on or off
-  void setBrightness(uint8_t brightness, bool on = true);
+    //! Sets the brightness of the display.
+    //!
+    //! The setting takes effect when a command is given to change the data being
+    //! displayed.
+    //!
+    //! @param brightness A number from 0 (lowes brightness) to 7 (highest brightness)
+    //! @param on Turn display on or off
+    void setBrightness(uint8_t brightness, bool on = true);
 
-  //! Display arbitrary data on the module
-  //!
-  //! This function receives raw segment values as input and displays them. The segment data
-  //! is given as a byte array, each byte corresponding to a single digit. Within each byte,
-  //! bit 0 is segment A, bit 1 is segment B etc.
-  //! The function may either set the entire display or any desirable part on its own. The first
-  //! digit is given by the @ref pos argument with 0 being the leftmost digit. The @ref length
-  //! argument is the number of digits to be set. Other digits are not affected.
-  //!
-  //! @param segments An array of size @ref length containing the raw segment values
-  //! @param length The number of digits to be modified
-  //! @param pos The position from which to start the modification (0 - leftmost, 3 - rightmost)
-  void setSegments(const uint8_t segments[], uint8_t length = 4, uint8_t pos = 0);
+    //! Display arbitrary data on the module
+    //!
+    //! This function receives raw segment values as input and displays them. The segment data
+    //! is given as a byte array, each byte corresponding to a single digit. Within each byte,
+    //! bit 0 is segment A, bit 1 is segment B etc.
+    //! The function may either set the entire display or any desirable part on its own. The first
+    //! digit is given by the @ref pos argument with 0 being the leftmost digit. The @ref length
+    //! argument is the number of digits to be set. Other digits are not affected.
+    //!
+    //! @param segments An array of size @ref length containing the raw segment values
+    //! @param length The number of digits to be modified
+    //! @param pos The position from which to start the modification (0 - leftmost, 3 - rightmost)
+    void setSegments(const uint8_t segments[], uint8_t length = 4, uint8_t pos = 0);
 
-  //! Clear the display
-  void clear();
+    //! Clear the display
+    void clear();
 
-  //! Display a decimal number
-  //!
-  //! Display the given argument as a decimal number.
-  //!
-  //! @param num The number to be shown
-  //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
-  //!        blank. NOTE: leading zero is not supported with negative numbers.
-  //! @param length The number of digits to set. The user must ensure that the number to be shown
-  //!        fits to the number of digits requested (for example, if two digits are to be displayed,
-  //!        the number must be between 0 to 99)
-  //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberDec(int num, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+    //! Display a decimal number
+    //!
+    //! Display the given argument as a decimal number.
+    //!
+    //! @param num The number to be shown
+    //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
+    //!        blank. NOTE: leading zero is not supported with negative numbers.
+    //! @param length The number of digits to set. The user must ensure that the number to be shown
+    //!        fits to the number of digits requested (for example, if two digits are to be displayed,
+    //!        the number must be between 0 to 99)
+    //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
+    void showNumberDec(int num, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
 
-  //! Display a decimal number, with dot control
-  //!
-  //! Display the given argument as a decimal number. The dots between the digits (or colon)
-  //! can be individually controlled.
-  //!
-  //! @param num The number to be shown
-  //! @param dots Dot/Colon enable. The argument is a bitmask, with each bit corresponding to a dot
-  //!        between the digits (or colon mark, as implemented by each module). i.e.
-  //!        For displays with dots between each digit:
-  //!        * 0.000 (0b10000000)
-  //!        * 00.00 (0b01000000)
-  //!        * 000.0 (0b00100000)
-  //!        * 0.0.0.0 (0b11100000)
-  //!        For displays with just a colon:
-  //!        * 00:00 (0b01000000)
-  //!        For displays with dots and colons colon:
-  //!        * 0.0:0.0 (0b11100000)
-  //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
-  //!        blank. NOTE: leading zero is not supported with negative numbers.
-  //! @param length The number of digits to set. The user must ensure that the number to be shown
-  //!        fits to the number of digits requested (for example, if two digits are to be displayed,
-  //!        the number must be between 0 to 99)
-  //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberDecEx(int num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+    //! Display a decimal number, with dot control
+    //!
+    //! Display the given argument as a decimal number. The dots between the digits (or colon)
+    //! can be individually controlled.
+    //!
+    //! @param num The number to be shown
+    //! @param dots Dot/Colon enable. The argument is a bitmask, with each bit corresponding to a dot
+    //!        between the digits (or colon mark, as implemented by each module). i.e.
+    //!        For displays with dots between each digit:
+    //!        * 0.000 (0b10000000)
+    //!        * 00.00 (0b01000000)
+    //!        * 000.0 (0b00100000)
+    //!        * 0.0.0.0 (0b11100000)
+    //!        For displays with just a colon:
+    //!        * 00:00 (0b01000000)
+    //!        For displays with dots and colons colon:
+    //!        * 0.0:0.0 (0b11100000)
+    //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
+    //!        blank. NOTE: leading zero is not supported with negative numbers.
+    //! @param length The number of digits to set. The user must ensure that the number to be shown
+    //!        fits to the number of digits requested (for example, if two digits are to be displayed,
+    //!        the number must be between 0 to 99)
+    //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
+    void showNumberDecEx(int num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
 
-  //! Display a hexadecimal number, with dot control
-  //!
-  //! Display the given argument as a hexadecimal number. The dots between the digits (or colon)
-  //! can be individually controlled.
-  //!
-  //! @param num The number to be shown
-  //! @param dots Dot/Colon enable. The argument is a bitmask, with each bit corresponding to a dot
-  //!        between the digits (or colon mark, as implemented by each module). i.e.
-  //!        For displays with dots between each digit:
-  //!        * 0.000 (0b10000000)
-  //!        * 00.00 (0b01000000)
-  //!        * 000.0 (0b00100000)
-  //!        * 0.0.0.0 (0b11100000)
-  //!        For displays with just a colon:
-  //!        * 00:00 (0b01000000)
-  //!        For displays with dots and colons colon:
-  //!        * 0.0:0.0 (0b11100000)
-  //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
-  //!        blank
-  //! @param length The number of digits to set. The user must ensure that the number to be shown
-  //!        fits to the number of digits requested (for example, if two digits are to be displayed,
-  //!        the number must be between 0 to 99)
-  //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberHexEx(uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+    //! Display a hexadecimal number, with dot control
+    //!
+    //! Display the given argument as a hexadecimal number. The dots between the digits (or colon)
+    //! can be individually controlled.
+    //!
+    //! @param num The number to be shown
+    //! @param dots Dot/Colon enable. The argument is a bitmask, with each bit corresponding to a dot
+    //!        between the digits (or colon mark, as implemented by each module). i.e.
+    //!        For displays with dots between each digit:
+    //!        * 0.000 (0b10000000)
+    //!        * 00.00 (0b01000000)
+    //!        * 000.0 (0b00100000)
+    //!        * 0.0.0.0 (0b11100000)
+    //!        For displays with just a colon:
+    //!        * 00:00 (0b01000000)
+    //!        For displays with dots and colons colon:
+    //!        * 0.0:0.0 (0b11100000)
+    //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
+    //!        blank
+    //! @param length The number of digits to set. The user must ensure that the number to be shown
+    //!        fits to the number of digits requested (for example, if two digits are to be displayed,
+    //!        the number must be between 0 to 99)
+    //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
+    void showNumberHexEx(uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
 
-  //! Display a string
-  //!
-  //! Display the given alphanumeric string.  The string can be of any length.  If it's longer than
-  //! the display or the length parameter, it gets cut.  If it's shorter, the remaining chars are
-  //! cleared.
-  //!
-  //! @param num The string to be displayed
-  //! @param length The number of digits to set.
-  //! @param pos The position of the first character (0 - leftmost, 3 - rightmost)
-  void showText(const char * text, uint8_t length = 4, uint8_t pos = 0);
+    //! Display a string
+    //!
+    //! Display the given alphanumeric string.  The string can be of any length.  If it's longer than
+    //! the display or the length parameter, it gets cut.  If it's shorter, the remaining chars are
+    //! cleared.
+    //!
+    //! @param num The string to be displayed
+    //! @param length The number of digits to set.
+    //! @param pos The position of the first character (0 - leftmost, 3 - rightmost)
+    void showText(const char * text, uint8_t length = 4, uint8_t pos = 0);
 
-  //! Translate a single digit into 7 segment code
-  //!
-  //! The method accepts a number between 0 - 15 and converts it to the
-  //! code required to display the number on a 7 segment display.
-  //! Numbers between 10-15 are converted to hexadecimal digits (A-F)
-  //!
-  //! @param digit A number between 0 to 15
-  //! @return A code representing the 7 segment image of the digit (LSB - segment A;
-  //!         bit 6 - segment G; bit 7 - always zero)
-  uint8_t encodeDigit(uint8_t digit);
+    //! Translate a single digit into 7 segment code
+    //!
+    //! The method accepts a number between 0 - 15 and converts it to the
+    //! code required to display the number on a 7 segment display.
+    //! Numbers between 10-15 are converted to hexadecimal digits (A-F)
+    //!
+    //! @param digit A number between 0 to 15
+    //! @return A code representing the 7 segment image of the digit (LSB - segment A;
+    //!         bit 6 - segment G; bit 7 - always zero)
+    uint8_t encodeDigit(uint8_t digit);
 
-  //! Translate a single char into 7 segment code
-  //!
-  //! The method accepts an alphanumeric character and converts it to the
-  //! code required to display the number on a 7 segment display.
-  //! Besides alphanumeric characters, the dash/minus sign is converted
-  //! properly to a code.  For all other characters, 0 is returned, which
-  //! means that none of the 7 segments is lit.
-  //!
-  //! @param digit An alphanumeric character or a dash
-  //! @return A code representing the 7 segment image of the char (LSB - segment A;
-  //!         bit 6 - segment G; bit 7 - always zero)
-  uint8_t encodeChar(char c);
+    //! Translate a single char into 7 segment code
+    //!
+    //! The method accepts an alphanumeric character and converts it to the
+    //! code required to display the number on a 7 segment display.
+    //! Besides alphanumeric characters, the dash/minus sign is converted
+    //! properly to a code.  For all other characters, 0 is returned, which
+    //! means that none of the 7 segments is lit.
+    //!
+    //! @param digit An alphanumeric character or a dash
+    //! @return A code representing the 7 segment image of the char (LSB - segment A;
+    //!         bit 6 - segment G; bit 7 - always zero)
+    uint8_t encodeChar(char c);
 
 protected:
-   void bitDelay();
+    void bitDelay();
 
-   void start();
+    void start();
 
-   void stop();
+    void stop();
 
-   bool writeByte(uint8_t b);
+    bool writeByte(uint8_t b);
 
-   void showDots(uint8_t dots, uint8_t* digits);
-   
-   void showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+    void showDots(uint8_t dots, uint8_t* digits);
+
+    void showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
 
 
 private:
-	uint8_t m_pinClk;
-	uint8_t m_pinDIO;
-	uint8_t m_brightness;
-	unsigned int m_bitDelay;
+    uint8_t m_pinClk;
+    uint8_t m_pinDIO;
+    uint8_t m_brightness;
+    unsigned int m_bitDelay;
 };
 
 #endif // __TM1637DISPLAY__

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -131,6 +131,17 @@ public:
   //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
   void showNumberHexEx(uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
 
+  //! Display a string
+  //!
+  //! Displays the given alphanumeric string.  The string can be of any length.  If it's longer than
+  //! the display or the length parameter, it gets cut.  If it's shorter, the remaining chars are
+  //! cleared.
+  //!
+  //! @param num The string to be displayed
+  //! @param length The number of digits to set.
+  //! @param pos The position of the first character (0 - leftmost, 3 - rightmost)
+  void showText(const char * text, uint8_t length = 4, uint8_t pos = 0);
+
   //! Translate a single digit into 7 segment code
   //!
   //! The method accepts a number between 0 - 15 and converts it to the
@@ -141,6 +152,19 @@ public:
   //! @return A code representing the 7 segment image of the digit (LSB - segment A;
   //!         bit 6 - segment G; bit 7 - always zero)
   uint8_t encodeDigit(uint8_t digit);
+
+  //! Translate a single char into 7 segment code
+  //!
+  //! The method accepts an alphanumeric character and converts it to the
+  //! code required to display the number on a 7 segment display.
+  //! Besides alphanumeric characters, the dash/minus sign is converted
+  //! properly to a code.  For all other characters, 0 is returned, which
+  //! means that none of the 7 segments is lit.
+  //!
+  //! @param digit An alphanumeric character or a dash
+  //! @return A code representing the 7 segment image of the char (LSB - segment A;
+  //!         bit 6 - segment G; bit 7 - always zero)
+  uint8_t encodeChar(char c);
 
 protected:
    void bitDelay();

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -70,7 +70,7 @@ public:
 
   //! Display a decimal number
   //!
-  //! Dispaly the given argument as a decimal number.
+  //! Display the given argument as a decimal number.
   //!
   //! @param num The number to be shown
   //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
@@ -83,7 +83,7 @@ public:
 
   //! Display a decimal number, with dot control
   //!
-  //! Dispaly the given argument as a decimal number. The dots between the digits (or colon)
+  //! Display the given argument as a decimal number. The dots between the digits (or colon)
   //! can be individually controlled.
   //!
   //! @param num The number to be shown
@@ -108,7 +108,7 @@ public:
 
   //! Display a hexadecimal number, with dot control
   //!
-  //! Dispaly the given argument as a hexadecimal number. The dots between the digits (or colon)
+  //! Display the given argument as a hexadecimal number. The dots between the digits (or colon)
   //! can be individually controlled.
   //!
   //! @param num The number to be shown
@@ -133,7 +133,7 @@ public:
 
   //! Display a string
   //!
-  //! Displays the given alphanumeric string.  The string can be of any length.  If it's longer than
+  //! Display the given alphanumeric string.  The string can be of any length.  If it's longer than
   //! the display or the length parameter, it gets cut.  If it's shorter, the remaining chars are
   //! cleared.
   //!

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,9 @@ clear			KEYWORD2
 showNumberDec		KEYWORD2
 showNumberDecEx		KEYWORD2
 showNumberHexEx		KEYWORD2
+showText		KEYWORD2
 encodeDigit		KEYWORD2
+encodeChar		KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Besides digits, a 7-segment display can also display letters.  The changes in this pull request add support for displaying letters (and text in general).  Of course, as there are only 7 segments, some letters look better than others, some can't really be properly displayed at all -- the mapping which defines what a given letter looks like on the display uses a best effort approach, suggestions to improve it are welcome.

The pull request also includes minor changes, which fix formatting inconsistencies (mainly tabs vs spaces in indentation) and typos in some of the comments.