### PR TITLE
Added showString() to display text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The library provides a single class named TM1637Display. An instance of this cla
 * `setSegments` - Set the raw value of the segments of each digit
 * `showNumberDec` - Display a decimal number
 * `showNumberDecEx` - Display a decimal number with decimal points or colon
+* `showString` - Display a ASCII string of text with scrolling  
 * `setBrightness` - Sets the brightness of the display
 
 The information given above is only a summary. Please refer to TM1637Display.h for more information. An example is included, demonstrating the operation of most of the functions.

--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -56,7 +56,108 @@ const uint8_t digitToSegment[] = {
   0b01110001     // F
   };
 
+// ASCII Map - Index 0 starts at ASCII 32
+const uint8_t asciiToSegment[] = {
+   0b00000000, // 032 (Space)
+   0b00110000, // 033 !
+   0b00100010, // 034 "
+   0b01000001, // 035 #
+   0b01101101, // 036 $
+   0b01010010, // 037 %
+   0b01111100, // 038 &
+   0b00100000, // 039 '
+   0b00111001, // 040 (
+   0b00001111, // 041 )
+   0b00100001, // 042 *
+   0b01110000, // 043 +
+   0b00001000, // 044 ,
+   0b01000000, // 045 -
+   0b00001000, // 046 .
+   0b01010010, // 047 /
+   0b00111111, // 048 0
+   0b00000110, // 049 1
+   0b01011011, // 050 2
+   0b01001111, // 051 3
+   0b01100110, // 052 4
+   0b01101101, // 053 5
+   0b01111101, // 054 6
+   0b00000111, // 055 7
+   0b01111111, // 056 8
+   0b01101111, // 057 9
+   0b01001000, // 058 :
+   0b01001000, // 059 ;
+   0b00111001, // 060 <
+   0b01001000, // 061 =
+   0b00001111, // 062 >
+   0b01010011, // 063 ?
+   0b01011111, // 064 @
+   0b01110111, // 065 A
+   0b01111100, // 066 B
+   0b00111001, // 067 C
+   0b01011110, // 068 D
+   0b01111001, // 069 E
+   0b01110001, // 070 F
+   0b00111101, // 071 G
+   0b01110110, // 072 H
+   0b00000110, // 073 I
+   0b00011110, // 074 J
+   0b01110110, // 075 K
+   0b00111000, // 076 L
+   0b00010101, // 077 M
+   0b00110111, // 078 N
+   0b00111111, // 079 O
+   0b01110011, // 080 P
+   0b01100111, // 081 Q
+   0b00110001, // 082 R
+   0b01101101, // 083 S
+   0b01111000, // 084 T
+   0b00111110, // 085 U
+   0b00011100, // 086 V
+   0b00101010, // 087 W
+   0b01110110, // 088 X
+   0b01101110, // 089 Y
+   0b01011011, // 090 Z
+   0b00111001, // 091 [
+   0b01100100, // 092 (backslash)
+   0b00001111, // 093 ]
+   0b00100011, // 094 ^
+   0b00001000, // 095 _
+   0b00100000, // 096 `
+   0b01110111, // 097 a
+   0b01111100, // 098 b
+   0b01011000, // 099 c
+   0b01011110, // 100 d
+   0b01111001, // 101 e
+   0b01110001, // 102 f
+   0b01101111, // 103 g
+   0b01110100, // 104 h
+   0b00000100, // 105 i
+   0b00011110, // 106 j
+   0b01110110, // 107 k
+   0b00011000, // 108 l
+   0b00010101, // 109 m
+   0b01010100, // 110 n
+   0b01011100, // 111 o
+   0b01110011, // 112 p
+   0b01100111, // 113 q
+   0b01010000, // 114 r
+   0b01101101, // 115 s
+   0b01111000, // 116 t
+   0b00111110, // 117 u
+   0b00011100, // 118 v
+   0b00101010, // 119 w
+   0b01110110, // 120 x
+   0b01101110, // 121 y
+   0b01011011, // 122 z
+   0b00111001, // 123 {
+   0b00110000, // 124 |
+   0b00001111, // 125 }
+   0b01000000, // 126 ~
+   0b00000000  // 127 
+};
+
 static const uint8_t minusSegments = 0b01000000;
+static const uint8_t degreeSegments = 0b01100011;
 
 TM1637Display::TM1637Display(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay)
 {
@@ -176,6 +277,54 @@ void TM1637Display::showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots, bo
     setSegments(digits, length, pos);
 }
 
+void TM1637Display::showString(char s[], unsigned int scrollDelay,
+                                    uint8_t length, uint8_t pos)
+{
+  uint8_t digits[4] = {0,0,0,0};
+
+  if (strlen(s) <= 4) {
+    switch (strlen(s)) {
+      case 4:
+        digits[3] = encodeASCII(s[3]);
+      case 3:
+        digits[2] = encodeASCII(s[2]);
+      case 2:
+        digits[1] = encodeASCII(s[1]);
+      case 1:
+        digits[0] = encodeASCII(s[0]);
+      case 0:
+        setSegments(digits, length, pos);
+    }
+  }
+  if (strlen(s) > 4) {
+    // Scroll text on display if too long
+    for (int x = 0; x < 3; x++) {  // scroll message on
+      digits[0] = digits[1];
+      digits[1] = digits[2];
+      digits[2] = digits[3];
+      digits[3] = encodeASCII(s[x]);
+      setSegments(digits, length, pos);
+      delay(scrollDelay);
+    }
+    for (int x = 3; x < strlen(s); x++) { // scroll through string
+      digits[0] = encodeASCII(s[x - 3]);
+      digits[1] = encodeASCII(s[x - 2]);
+      digits[2] = encodeASCII(s[x - 1]);
+      digits[3] = encodeASCII(s[x]);
+      setSegments(digits, length, pos);
+      delay(scrollDelay);
+    }
+    for (int x = 0; x < 4; x++) {  // scroll message off
+      digits[0] = digits[1];
+      digits[1] = digits[2];
+      digits[2] = digits[3];
+      digits[3] = 0;
+      setSegments(digits, length, pos);
+      delay(scrollDelay);
+    }
+  }
+}
+
 void TM1637Display::bitDelay()
 {
 	delayMicroseconds(m_bitDelay);
@@ -254,4 +403,11 @@ void TM1637Display::showDots(uint8_t dots, uint8_t* digits)
 uint8_t TM1637Display::encodeDigit(uint8_t digit)
 {
 	return digitToSegment[digit & 0x0f];
+}
+
+uint8_t TM1637Display::encodeASCII(uint8_t chr)
+{
+  if(chr == 176) return degreeSegments;   // degree mark
+  if(chr > 127 || chr < 32) return 0;     // blank
+	return asciiToSegment[chr - 32];
 }

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -142,6 +142,27 @@ public:
   //!         bit 6 - segment G; bit 7 - always zero)
   uint8_t encodeDigit(uint8_t digit);
 
+  //! Display a string
+  //!
+  //! Dispaly the given string and if more than 4 characters, will scroll message on display
+  //!
+  //! @param s The string to be shown
+  //! @param scrollDelay  The delay, in microseconds to wait before scrolling to next frame
+  //! @param length The number of digits to set. 
+  //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
+  void showString(char s[], unsigned int scrollDelay = 200, uint8_t length = 4, uint8_t pos = 0);
+ 
+  //! Translate a single ASCII character into 7 segment code
+  //!
+  //! The method accepts a number between 0 - 255 and converts it to the
+  //! code required to display the number on a 7 segment display.
+  //! ASCII Characters between 0-32 and 128-255 are blank.
+  //!
+  //! @param chr A character ASCII value 
+  //! @return A code representing the 7 segment image of the digit (LSB - segment A;
+  //!         bit 6 - segment G; bit 7 - always zero)
+  uint8_t TM1637Display::encodeASCII(uint8_t chr);
+
 protected:
    void bitDelay();
 

--- a/examples/TM1637Test/TM1637Test.ino
+++ b/examples/TM1637Test/TM1637Test.ino
@@ -9,11 +9,11 @@
 #define TEST_DELAY   2000
 
 const uint8_t SEG_DONE[] = {
-	SEG_B | SEG_C | SEG_D | SEG_E | SEG_G,           // d
-	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F,   // O
-	SEG_C | SEG_E | SEG_G,                           // n
-	SEG_A | SEG_D | SEG_E | SEG_F | SEG_G            // E
-	};
+  SEG_B | SEG_C | SEG_D | SEG_E | SEG_G,           // d
+  SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F,   // O
+  SEG_C | SEG_E | SEG_G,                           // n
+  SEG_A | SEG_D | SEG_E | SEG_F | SEG_G            // E
+};
 
 TM1637Display display(CLK, DIO);
 
@@ -41,10 +41,10 @@ void loop()
   delay(TEST_DELAY);
 
   /*
-  for(k = 3; k >= 0; k--) {
-	display.setSegments(data, 1, k);
-	delay(TEST_DELAY);
-	}
+    for(k = 3; k >= 0; k--) {
+    display.setSegments(data, 1, k);
+    delay(TEST_DELAY);
+    }
   */
 
   display.clear();
@@ -65,8 +65,8 @@ void loop()
   delay(TEST_DELAY);
   display.showNumberDec(0, true);  // Expect: 0000
   delay(TEST_DELAY);
-	display.showNumberDec(1, false); // Expect: ___1
-	delay(TEST_DELAY);
+  display.showNumberDec(1, false); // Expect: ___1
+  delay(TEST_DELAY);
   display.showNumberDec(1, true);  // Expect: 0001
   delay(TEST_DELAY);
   display.showNumberDec(301, false); // Expect: _301
@@ -97,22 +97,22 @@ void loop()
   display.clear();
   display.showNumberHexEx(0xd1, 0, true, 2); // Expect: d1__
   delay(TEST_DELAY);
-  
-	// Run through all the dots
-	for(k=0; k <= 4; k++) {
-		display.showNumberDecEx(0, (0x80 >> k), true);
-		delay(TEST_DELAY);
-	}
+
+  // Run through all the dots
+  for(k=0; k <= 4; k++) {
+    display.showNumberDecEx(0, (0x80 >> k), true);
+    delay(TEST_DELAY);
+  }
 
   // Brightness Test
   for(k = 0; k < 4; k++)
-	data[k] = 0xff;
+    data[k] = 0xff;
   for(k = 0; k < 7; k++) {
     display.setBrightness(k);
     display.setSegments(data);
     delay(TEST_DELAY);
   }
-  
+
   // On/Off test
   for(k = 0; k < 4; k++) {
     display.setBrightness(7, false);  // Turn off
@@ -120,10 +120,26 @@ void loop()
     delay(TEST_DELAY);
     display.setBrightness(7, true); // Turn on
     display.setSegments(data);
-    delay(TEST_DELAY);  
+    delay(TEST_DELAY);
   }
 
- 
+  // String tests
+  display.clear();
+  display.showString("String Test 1234");
+  delay(TEST_DELAY);
+  display.clear();
+  display.showString("25\xB0\C");
+  delay(TEST_DELAY);
+  display.clear();
+  display.showString("abcdefghijklmnopqrstuvwxyz.-=ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  delay(TEST_DELAY);
+  display.clear();
+  display.showString("The");
+  delay(TEST_DELAY);
+  display.clear();
+  display.showString("End");
+  delay(TEST_DELAY);
+
   // Done!
   display.setSegments(SEG_DONE);
 


### PR DESCRIPTION
This PR adds an ASCII character to 7-segment LED map and a `showString()` function to allow sending strings of ASCII text to the display.  For strings longer than the display (4 characters) the function will scroll the string using default `scrollDelay` value or param. 

```cpp
void showString(char s[], unsigned int scrollDelay = 200, 
                 uint8_t length = 4, uint8_t pos = 0);

uint8_t TM1637Display::encodeASCII(uint8_t chr);
```

The following is also added to the `TM1637Test.ino` test sketch:
```cpp
  // String tests
  display.clear();
  display.showString("String Test 1234");
  delay(TEST_DELAY);
  display.clear();
  display.showString("25\xB0\C");
  delay(TEST_DELAY);
  display.clear();
  display.showString("abcdefghijklmnopqrstuvwxyz.-=ABCDEFGHIJKLMNOPQRSTUVWXYZ");
  delay(TEST_DELAY);
  display.clear();
  display.showString("The");
  delay(TEST_DELAY);
  display.clear();
  display.showString("End");
  delay(TEST_DELAY);
```