### PR TITLE
Mark TM1637Display::encodeDigit static

### DIFF
--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -140,7 +140,7 @@ public:
   //! @param digit A number between 0 to 15
   //! @return A code representing the 7 segment image of the digit (LSB - segment A;
   //!         bit 6 - segment G; bit 7 - always zero)
-  uint8_t encodeDigit(uint8_t digit);
+  static uint8_t encodeDigit(uint8_t digit);
 
 protected:
    void bitDelay();

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -70,7 +70,7 @@ public:
 
   //! Display a decimal number
   //!
-  //! Dispaly the given argument as a decimal number.
+  //! Display the given argument as a decimal number.
   //!
   //! @param num The number to be shown
   //! @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
@@ -83,7 +83,7 @@ public:
 
   //! Display a decimal number, with dot control
   //!
-  //! Dispaly the given argument as a decimal number. The dots between the digits (or colon)
+  //! Display the given argument as a decimal number. The dots between the digits (or colon)
   //! can be individually controlled.
   //!
   //! @param num The number to be shown
@@ -108,7 +108,7 @@ public:
 
   //! Display a hexadecimal number, with dot control
   //!
-  //! Dispaly the given argument as a hexadecimal number. The dots between the digits (or colon)
+  //! Display the given argument as a hexadecimal number. The dots between the digits (or colon)
   //! can be individually controlled.
   //!
   //! @param num The number to be shown


### PR DESCRIPTION
This makes it easier to use the encode helper outside of the class. It's already a public member, so why not.

It's a tiny change and simply building it should be enough to verify that it works, but I built and ran the example sketch just to be sure.