### PR TITLE
Added support for 6 digit displays with digit remapping

### DIFF
--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -30,6 +30,8 @@
 
 #define DEFAULT_BIT_DELAY  100
 
+#define MAX_DIGIT_COUNT (6) // maximum that the TM1637 supports
+
 class TM1637Display {
 
 public:
@@ -40,7 +42,13 @@ public:
   //! @param pinDIO - The number of the digital pin connected to the DIO pin of the module
   //! @param bitDelay - The delay, in microseconds, between bit transition on the serial
   //!                   bus connected to the display
-  TM1637Display(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay = DEFAULT_BIT_DELAY);
+  //! @param digitCount - number of digits on the display (ie 4, 6)
+  TM1637Display(
+          uint8_t pinClk, 
+          uint8_t pinDIO, 
+          unsigned int bitDelay = DEFAULT_BIT_DELAY, 
+          uint8_t digitCount = 4, 
+          uint8_t * digitRemap = NULL);
 
   //! Sets the brightness of the display.
   //!
@@ -63,7 +71,7 @@ public:
   //! @param segments An array of size @ref length containing the raw segment values
   //! @param length The number of digits to be modified
   //! @param pos The position from which to start the modification (0 - leftmost, 3 - rightmost)
-  void setSegments(const uint8_t segments[], uint8_t length = 4, uint8_t pos = 0);
+  void setSegments(const uint8_t segments[], uint8_t length = 255, uint8_t pos = 0);
 
   //! Clear the display
   void clear();
@@ -79,7 +87,7 @@ public:
   //!        fits to the number of digits requested (for example, if two digits are to be displayed,
   //!        the number must be between 0 to 99)
   //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberDec(int num, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+  void showNumberDec(int num, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
   //! Display a decimal number, with dot control
   //!
@@ -104,7 +112,7 @@ public:
   //!        fits to the number of digits requested (for example, if two digits are to be displayed,
   //!        the number must be between 0 to 99)
   //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberDecEx(int num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+  void showNumberDecEx(int num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
   //! Display a hexadecimal number, with dot control
   //!
@@ -129,7 +137,7 @@ public:
   //!        fits to the number of digits requested (for example, if two digits are to be displayed,
   //!        the number must be between 0 to 99)
   //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberHexEx(uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+  void showNumberHexEx(uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
   //! Translate a single digit into 7 segment code
   //!
@@ -153,7 +161,7 @@ protected:
 
    void showDots(uint8_t dots, uint8_t* digits);
    
-   void showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 4, uint8_t pos = 0);
+   void showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
 
 private:
@@ -161,6 +169,8 @@ private:
 	uint8_t m_pinDIO;
 	uint8_t m_brightness;
 	unsigned int m_bitDelay;
+  uint8_t m_digitCount;
+  uint8_t * m_digitRemap;
 };
 
 #endif // __TM1637DISPLAY__

--- a/examples/TM1637_6digit_Test/TM1637_6digit_Test.ino
+++ b/examples/TM1637_6digit_Test/TM1637_6digit_Test.ino
@@ -1,0 +1,146 @@
+#include <Arduino.h>
+#include <TM1637Display.h>
+
+// Module connection pins (Digital Pins)
+#define CLK 2
+#define DIO 3
+
+// The amount of time (in milliseconds) between tests
+#define TEST_DELAY   1000
+
+const uint8_t SEG_DONE[] = {
+  SEG_B | SEG_C | SEG_D | SEG_E | SEG_G,           // d
+  SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F,   // O
+  SEG_C | SEG_E | SEG_G,                           // n
+  SEG_A | SEG_D | SEG_E | SEG_F | SEG_G,           // E
+  SEG_DP,                                          // .
+  SEG_DP,                                          // .
+  };
+
+
+const uint8_t digit_remapping[] = { 2, 1, 0, 5, 4, 3 };
+
+TM1637Display display(CLK, DIO, DEFAULT_BIT_DELAY, 6, digit_remapping );
+
+void setup()
+{
+}
+
+void loop()
+{
+  int k;
+  uint8_t data[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+  //uint8_t blank[] = { 0x00, 0x00, 0x00, 0x00 };
+  display.setBrightness(0x0f);
+
+  // All segments on
+  display.setSegments(data);
+  delay(TEST_DELAY);
+
+  // Selectively set different digits
+  data[0] = display.encodeDigit(0);
+  data[1] = display.encodeDigit(1);
+  data[2] = display.encodeDigit(2);
+  data[3] = display.encodeDigit(3);
+  data[4] = display.encodeDigit(4);
+  data[5] = display.encodeDigit(5);
+  display.setSegments(data);
+  delay(TEST_DELAY);
+
+  /*
+  for(k = 3; k >= 0; k--) {
+  display.setSegments(data, 1, k);
+  delay(TEST_DELAY);
+  }
+  */
+
+  display.clear();
+  display.setSegments(data+2, 2, 2);
+  delay(TEST_DELAY);
+
+  display.clear();
+  display.setSegments(data+2, 2, 1);
+  delay(TEST_DELAY);
+
+  display.clear();
+  display.setSegments(data+1, 3, 1);
+  delay(TEST_DELAY);
+
+
+  // Show decimal numbers with/without leading zeros
+  display.showNumberDec(0, false); // Expect: ___0
+  delay(TEST_DELAY);
+  display.showNumberDec(0, true);  // Expect: 0000
+  delay(TEST_DELAY);
+  display.showNumberDec(1, false); // Expect: ___1
+  delay(TEST_DELAY);
+  display.showNumberDec(1, true);  // Expect: 0001
+  delay(TEST_DELAY);
+  display.showNumberDec(301, false); // Expect: _301
+  delay(TEST_DELAY);
+  display.showNumberDec(301, true); // Expect: 0301
+  delay(TEST_DELAY);
+  display.clear();
+  display.showNumberDec(14, false, 2, 1); // Expect: _14_
+  delay(TEST_DELAY);
+  display.clear();
+  display.showNumberDec(4, true, 2, 2);  // Expect: __04
+  delay(TEST_DELAY);
+  display.showNumberDec(-1, false);  // Expect: __-1
+  delay(TEST_DELAY);
+  display.showNumberDec(-12);        // Expect: _-12
+  delay(TEST_DELAY);
+  display.showNumberDec(-999);       // Expect: -999
+  delay(TEST_DELAY);
+  display.clear();
+  display.showNumberDec(-5, false, 3, 0); // Expect: _-5_
+  delay(TEST_DELAY);
+  display.showNumberHexEx(0xf1af);        // Expect: f1Af
+  delay(TEST_DELAY);
+  display.showNumberHexEx(0x2c);          // Expect: __2C
+  delay(TEST_DELAY);
+  display.showNumberHexEx(0xd1, 0, true); // Expect: 00d1
+  delay(TEST_DELAY);
+  display.clear();
+  display.showNumberHexEx(0xd1, 0, true, 2); // Expect: d1__
+  delay(TEST_DELAY);
+  
+  // Run through all the dots
+  for(k=0; k <= 6; k++) {
+    display.showNumberDecEx(0, (0x80 >> k), true);
+    delay(TEST_DELAY);
+  }
+
+  // Brightness Test
+  for(k = 0; k < 6; k++)
+   data[k] = 0xff;
+
+  for(k = 0; k < 7; k++) {
+    display.setBrightness(k);
+    display.setSegments(data);
+    delay(TEST_DELAY/4);
+  }
+  
+  // On/Off test
+  for(k = 0; k < 4; k++) {
+    display.setBrightness(7, false);  // Turn off
+    display.setSegments(data);
+    delay(TEST_DELAY/4);
+    display.setBrightness(7, true); // Turn on
+    display.setSegments(data);
+    delay(TEST_DELAY/4);  
+  }
+
+ 
+  // Done!
+  while(1) {
+    display.setBrightness(7);
+    display.setSegments(SEG_DONE);
+    delay( TEST_DELAY/4 );
+
+    display.setBrightness(1);
+    display.setSegments(SEG_DONE);
+    delay( TEST_DELAY/4 );
+
+  }
+}


### PR DESCRIPTION
I added support for 6 digit displays, as well as remapping the order of the digits themselves.  (The controller chip can support up to 6 digits.)

I did it by adding optional parameters on the constructor.  With no changes, the original 4-digit behavior is preserved.
I added a 6 digit example that shows the remapping.

Some of the functions don't seem to work properly now, but everything else works great.